### PR TITLE
refactor: use self._attr_XYZ to reduce overhead

### DIFF
--- a/custom_components/hafas/sensor.py
+++ b/custom_components/hafas/sensor.py
@@ -88,8 +88,7 @@ class HaFAS(SensorEntity):
 
         self.journeys: list[Journey] = []
 
-    @property
-    def native_value(self) -> str:
+    def calc_native_value(self) -> str:
         """Return the departure time of the next train."""
         if (
             len(self.journeys) == 0
@@ -111,8 +110,7 @@ class HaFAS(SensorEntity):
 
         return value
 
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
+    def calc_extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         if (
             len(self.journeys) == 0
@@ -182,3 +180,6 @@ class HaFAS(SensorEntity):
                 max_journeys=3,
             )
         )
+
+        self._attr_native_value = self.calc_native_value()
+        self._attr_extra_state_attributes = self.calc_extra_state_attributes()

--- a/custom_components/hafas/sensor.py
+++ b/custom_components/hafas/sensor.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
-from .const import CONF_DESTINATION, CONF_ONLY_DIRECT, CONF_START, DOMAIN
+from .const import CONF_DESTINATION, CONF_ONLY_DIRECT, CONF_PROFILE, CONF_START, DOMAIN
 
 ICON = "mdi:train"
 SCAN_INTERVAL = timedelta(minutes=2)
@@ -51,6 +51,7 @@ async def async_setup_entry(
                 entry.data[CONF_ONLY_DIRECT],
                 entry.title,
                 entry.entry_id,
+                entry.data[CONF_PROFILE],
             )
         ],
         True,
@@ -70,6 +71,7 @@ class HaFAS(SensorEntity):
         only_direct: bool,
         title: str,
         entry_id: str,
+        profile: str,
     ) -> None:
         """Initialize the sensor."""
         self.hass = hass
@@ -81,6 +83,7 @@ class HaFAS(SensorEntity):
         self._name = title
 
         self._attr_unique_id = entry_id
+        self._attr_attribution = "Provided by " + profile + " through HaFAS API"
 
         self.journeys: list[Journey] = []
 

--- a/custom_components/hafas/sensor.py
+++ b/custom_components/hafas/sensor.py
@@ -80,22 +80,13 @@ class HaFAS(SensorEntity):
         self.destination = destination_station
         self.offset = offset
         self.only_direct = only_direct
-        self._name = title
 
+        self._attr_name = title
+        self._attr_icon = ICON
         self._attr_unique_id = entry_id
         self._attr_attribution = "Provided by " + profile + " through HaFAS API"
 
         self.journeys: list[Journey] = []
-
-    @property
-    def name(self) -> str:
-        """Return the name of the sensor."""
-        return self._name
-
-    @property
-    def icon(self) -> str:
-        """Return the icon for the frontend."""
-        return ICON
 
     @property
     def native_value(self) -> str:


### PR DESCRIPTION
As data only changes during `async_update`, we can store all attributes in `self._attr_*`. That way we reduce computational overhead. See also https://developers.home-assistant.io/docs/core/entity/#property-implementation.

Also add attribution to sensors.