### PR TITLE
feat!: re-structure state and attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![validate with HACS action](https://img.shields.io/github/actions/workflow/status/akloeckner/hacs-hafas/hassfest.yaml?label=validate%20with%20HACS%20action)](https://github.com/akloeckner/hacs-hafas/actions/workflows/hacs.yaml)
 [![GitHub commits since latest release](https://img.shields.io/github/commits-since/akloeckner/hacs-hafas/latest)](https://github.com/akloeckner/hacs-hafas/compare/...master)
 
-[![Open this repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=akloeckner&repository=hacs-hafas)
+[![Open this repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=akloeckner&repository=hacs-hafas&category=transport)
 [![Show this integration in your Home Assistant.](https://my.home-assistant.io/badges/integration.svg)](https://my.home-assistant.io/redirect/integration/?domain=hafas)
 
 A custom component for Home Assistant providing a client for the HAFAS API.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,79 @@
-# HAFAS (HaCon Fahrplan-Auskunfts-System) client
+# HAFAS (HaCon Fahrplan-Auskunfts-System) integration for Home Assistant
 
 [![validate with hassfest](https://img.shields.io/github/actions/workflow/status/akloeckner/hacs-hafas/hassfest.yaml?label=validate%20with%20hassfest)](https://github.com/akloeckner/hacs-hafas/actions/workflows/hassfest.yaml)
 [![validate with HACS action](https://img.shields.io/github/actions/workflow/status/akloeckner/hacs-hafas/hassfest.yaml?label=validate%20with%20HACS%20action)](https://github.com/akloeckner/hacs-hafas/actions/workflows/hacs.yaml)
 [![GitHub commits since latest release](https://img.shields.io/github/commits-since/akloeckner/hacs-hafas/latest)](https://github.com/akloeckner/hacs-hafas/compare/...master)
 
-A custom component for Home Assistant providing a client for the HAFAS API.
-It can be used to retrieve connection data for a number of public transport companies in Europe.
+[![Open this repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=akloeckner&repository=hacs-hafas)
+[![Show this integration in your Home Assistant.](https://my.home-assistant.io/badges/integration.svg)](https://my.home-assistant.io/redirect/integration/?domain=hafas)
 
-Credit goes to @kilimnik. This is just a proof of concept to use this component with HACS.
+A custom component for Home Assistant providing a client for the HAFAS API.
+It can be used to retrieve connection data for a number of public transport companies in Europe, most notably Deutsche Bahn.
+
+Credit goes to [@kilimnik](https://github.com/kilimnik).
+
+## Sensor data
+
+Once configured, this integration provides a sensor to show the next connections between two stations.
+
+The `state` of the sensor is the `timestamp` of the next non-cancelled departure including delay. This allows to use the `state` programmatically, e.g., to compute a `timedelta` from it. Also, the sensor will be shown natively in Lovelace as a relative time, such as "in 5 minutes".
+
+The `attributes` will contain the following additional data:
+* `connections`: a list of all connections retrieved (see below)
+* plus all information from the first non-canceled connection, except its list of `legs`
+
+**Note**: The `connections` attribute is not recorded in history, because it contains a lot of data.
+And we don't want to bloat your home assistant database.
+
+Each entry in the `connections` list contains the following data:
+* `origin`: name of origin station 
+* `departure`: timestamp of planned departure 
+* `delay`: timedelta of departure delay 
+* `destination`: name of destination station 
+* `arrival`: timestamp of planned arrival 
+* `delay_arrival`: timedelta of arrival delay 
+* `transfers`: number of legs minus one
+* `duration`: timedelta from departure to arrival
+* `canceled`: Boolean, `true` if any leg is canceled else `false`
+* `ontime`: Boolean, `true` if zero departure delay else `false`
+* `products`: comma-separated list of line names
+* `legs`: list of legs with more detailed information
+
+Each connection can consist of multiple legs (different trains with transfers in between).
+A leg contains the following data:
+* `origin`: name of origin station
+* `departure`: timestamp of planned departure
+* `platform`: departure platform
+* `delay`: timedelta of departure delay
+* `destination`: name of destination station 
+* `arrival`: timestamp of planned arrival 
+* `platform_arrival`: arrival platform 
+* `delay_arrival`: timedelta of arrival delay
+* `mode`: transport mode such as `train`
+* `name`: name of transport line such as `RE123`
+* `canceled`: Boolean, if this leg is canceled
+* `distance`: walking distance if any (only walking legs)
+* `remarks`: list of strings
+* `stopovers`: list of station names
+
+## Usage examples of attribute data in templates
+
+Generate an output as in the old `db` integration, e.g., `11:11 + 11`:
+```python
+{%- set departure = state_attr('sensor.koln_hbf_to_frankfurt_main_hbf', 'departure') | as_local %}
+{%- set delay = state_attr('sensor.koln_hbf_to_frankfurt_main_hbf', 'delay') | as_timedelta %}
+{{- departure.strftime('%H:%M') }}
+{%- if delay -%}
+  {{- ' + ' ~ (delay.total_seconds() // 60) | int -}}
+{%- endif -%}
+```
+
+Only retrieve the planned departure timestamps of all non-canceled connections:
+```python
+{{ state_attr('sensor.koln_hbf_to_frankfurt_main_hbf', 'connections')
+   | rejectattr('canceled')
+   | map(attribute='departure')
+   | list }}
+```
+
+

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# HAFAS (HaCon Fahrplan-Auskunfts-System) integration for Home Assistant
+# HAFAS (HaCon Fahrplan-Auskunfts-System)
 
 [![validate with hassfest](https://img.shields.io/github/actions/workflow/status/akloeckner/hacs-hafas/hassfest.yaml?label=validate%20with%20hassfest)](https://github.com/akloeckner/hacs-hafas/actions/workflows/hassfest.yaml)
 [![validate with HACS action](https://img.shields.io/github/actions/workflow/status/akloeckner/hacs-hafas/hassfest.yaml?label=validate%20with%20HACS%20action)](https://github.com/akloeckner/hacs-hafas/actions/workflows/hacs.yaml)
 [![GitHub commits since latest release](https://img.shields.io/github/commits-since/akloeckner/hacs-hafas/latest)](https://github.com/akloeckner/hacs-hafas/compare/...master)
+![Number of installations](https://img.shields.io/badge/dynamic/json?label=installations&url=https://analytics.home-assistant.io/custom_integrations.json&query=$.hafas.total)
 
 [![Open this repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=akloeckner&repository=hacs-hafas&category=transport)
 [![Show this integration in your Home Assistant.](https://my.home-assistant.io/badges/integration.svg)](https://my.home-assistant.io/redirect/integration/?domain=hafas)
@@ -10,7 +11,7 @@
 A custom component for Home Assistant providing a client for the HAFAS API.
 It can be used to retrieve connection data for a number of public transport companies in Europe, most notably Deutsche Bahn.
 
-Credit goes to [@kilimnik](https://github.com/kilimnik).
+Credit goes to [@kilimnik](https://github.com/kilimnik) and [pyhafas](https://github.com/FahrplanDatenGarten/pyhafas).
 
 ## Sensor data
 

--- a/custom_components/hafas/config_flow.py
+++ b/custom_components/hafas/config_flow.py
@@ -32,7 +32,8 @@ class Profile(StrEnum):
 PROFILE_OPTIONS = [
     selector.SelectOptionDict(value=Profile.DB, label="Deutsche Bahn"),
     selector.SelectOptionDict(
-        value=Profile.KVB, label="Kölner Verkehrs-Betriebe",
+        value=Profile.KVB,
+        label="Kölner Verkehrs-Betriebe",
     ),
     selector.SelectOptionDict(
         value=Profile.VSN, label="Verkehrsverbund Süd-Niedersachsen"

--- a/custom_components/hafas/manifest.json
+++ b/custom_components/hafas/manifest.json
@@ -1,15 +1,15 @@
 {
-  "domain": "hafas",
-  "name": "HaFAS",
-  "codeowners": ["@kilimnik"],
-  "config_flow": true,
-  "dependencies": [],
-  "documentation": "https://www.home-assistant.io/integrations/hafas",
-  "homekit": {},
-  "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/akloeckner/hacs-hafas/issues",
-  "requirements": ["pyhafas~=0.5"],
-  "ssdp": [],
-  "version": "0.0.1",
-  "zeroconf": []
+    "domain": "hafas",
+    "name": "HaFAS",
+    "codeowners": ["@kilimnik"],
+    "config_flow": true,
+    "dependencies": [],
+    "documentation": "https://www.home-assistant.io/integrations/hafas",
+    "homekit": {},
+    "iot_class": "cloud_polling",
+    "issue_tracker": "https://github.com/akloeckner/hacs-hafas/issues",
+    "requirements": ["pyhafas~=0.5"],
+    "ssdp": [],
+    "version": "0.0.1",
+    "zeroconf": []
 }

--- a/custom_components/hafas/sensor.py
+++ b/custom_components/hafas/sensor.py
@@ -20,7 +20,7 @@ from .const import CONF_DESTINATION, CONF_ONLY_DIRECT, CONF_PROFILE, CONF_START,
 from .utils import to_dict
 
 ICON = "mdi:train"
-SCAN_INTERVAL = timedelta(minutes=2)
+SCAN_INTERVAL = timedelta(seconds=30)
 
 
 async def async_setup_entry(

--- a/custom_components/hafas/sensor.py
+++ b/custom_components/hafas/sensor.py
@@ -62,6 +62,12 @@ async def async_setup_entry(
 class HaFAS(SensorEntity):
     """Implementation of a HaFAS sensor."""
 
+    _unrecorded_attributes = frozenset(
+        {
+            "connections",
+        }
+    )
+
     def __init__(
         self,
         hass: HomeAssistant,

--- a/custom_components/hafas/sensor.py
+++ b/custom_components/hafas/sensor.py
@@ -100,7 +100,9 @@ class HaFAS(SensorEntity):
         """Update the journeys using pyhafas."""
 
         self._attr_native_value = None
-        self._attr_extra_state_attributes = {}
+        self._attr_extra_state_attributes = {
+            "connections": [],
+        }
 
         self.journeys = await self.hass.async_add_executor_job(
             functools.partial(
@@ -117,6 +119,8 @@ class HaFAS(SensorEntity):
             return
 
         connections = to_dict(self.journeys)
+        self._attr_extra_state_attributes["connections"] = connections
+
         # use get method, because an empty Journey would return {}
         running = [x for x in connections if not x.get("canceled", True)]
 
@@ -128,7 +132,6 @@ class HaFAS(SensorEntity):
         )
 
         # use decomposition to not modify the original object
-        self._attr_extra_state_attributes = {
+        self._attr_extra_state_attributes |= {
             k: v for k, v in running[0].items() if k != "legs"
         }
-        self._attr_extra_state_attributes["connections"] = connections

--- a/custom_components/hafas/sensor.py
+++ b/custom_components/hafas/sensor.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
 from .const import CONF_DESTINATION, CONF_ONLY_DIRECT, CONF_PROFILE, CONF_START, DOMAIN
+from .utils import to_dict
 
 ICON = "mdi:train"
 SCAN_INTERVAL = timedelta(minutes=2)
@@ -143,6 +144,7 @@ class HaFAS(SensorEntity):
             "delay": str(delay),
             "canceled": first_leg.cancelled,
             "delay_arrival": str(delay_arrival),
+            "raw": to_dict(self.journeys),
         }
 
         next_connection = "No connection possible"

--- a/custom_components/hafas/sensor.py
+++ b/custom_components/hafas/sensor.py
@@ -19,7 +19,7 @@ import homeassistant.util.dt as dt_util
 from .const import CONF_DESTINATION, CONF_ONLY_DIRECT, CONF_PROFILE, CONF_START, DOMAIN
 from .utils import to_dict
 
-ICON = "mdi:train"
+ICON = "mdi:timetable"
 SCAN_INTERVAL = timedelta(seconds=30)
 
 

--- a/custom_components/hafas/sensor.py
+++ b/custom_components/hafas/sensor.py
@@ -101,12 +101,7 @@ class HaFAS(SensorEntity):
 
         if len(running) > 0:
             return running[0]["departure"] + (
-                (
-                    datetime.strptime(running[0]["delay"], "%H:%M:%S")
-                    - datetime.strptime("0:00:00", "%H:%M:%S")
-                )
-                if running[0]["delay"]
-                else 0
+                dt_util.parse_duration(running[0]["delay"]) or timedelta()
             )
 
         return None
@@ -129,23 +124,13 @@ class HaFAS(SensorEntity):
         attributes["next"] = None
         if len(running) > 1:
             attributes["next"] = running[1]["departure"] + (
-                (
-                    datetime.strptime(running[1]["delay"], "%H:%M:%S")
-                    - datetime.strptime("0:00:00", "%H:%M:%S")
-                )
-                if running[1]["delay"]
-                else 0
+                dt_util.parse_duration(running[1]["delay"]) or timedelta()
             )
 
         attributes["next_on"] = None
         if len(running) > 2:
             attributes["next_on"] = running[2]["departure"] + (
-                (
-                    datetime.strptime(running[2]["delay"], "%H:%M:%S")
-                    - datetime.strptime("0:00:00", "%H:%M:%S")
-                )
-                if running[2]["delay"]
-                else 0
+                dt_util.parse_duration(running[2]["delay"]) or timedelta()
             )
 
         attributes["connections"] = connections

--- a/custom_components/hafas/sensor.py
+++ b/custom_components/hafas/sensor.py
@@ -9,9 +9,9 @@ from typing import Any
 from pyhafas import HafasClient
 from pyhafas.types.fptf import Journey, Station
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_OFFSET, DEVICE_CLASS_TIMESTAMP
+from homeassistant.const import CONF_OFFSET
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
@@ -85,7 +85,7 @@ class HaFAS(SensorEntity):
         self._attr_name = title
         self._attr_icon = ICON
         self._attr_unique_id = entry_id
-        self._attr_device_class = DEVICE_CLASS_TIMESTAMP
+        self._attr_device_class = SensorDeviceClass.TIMESTAMP
         self._attr_attribution = "Provided by " + profile + " through HaFAS API"
 
         self.journeys: list[Journey] = []

--- a/custom_components/hafas/utils.py
+++ b/custom_components/hafas/utils.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime, timedelta
 from pyhafas.types.fptf import Journey, Leg, Remark, Stopover
 
-def timedelta_to_dict(item):
+def timedelta_to_str(item):
     return str(item) if item else '0:00:00'
 
 # see https://gist.github.com/sungitly/3f75cb297572dace2937?permalink_comment_id=4211196#gistcomment-4211196
@@ -19,12 +19,12 @@ def to_dict(item):
             return {
                 "origin":        item.legs[ 0].origin.name,
                 "departure":     item.legs[ 0].departure,
-                "delay":         timedelta_to_dict(item.legs[ 0].departureDelay),
+                "delay":         timedelta_to_str(item.legs[ 0].departureDelay),
                 "destination":   item.legs[-1].destination.name,
                 "arrival":       item.legs[-1].arrival,
-                "delay_arrival": timedelta_to_dict(item.legs[-1].arrivalDelay),
+                "delay_arrival": timedelta_to_str(item.legs[-1].arrivalDelay),
                 "transfers":     len(item.legs) - 1,
-                "duration":      str(item.duration),
+                "duration":      timedelta_to_str(item.duration),
                 "canceled":      any([x.cancelled for x in item.legs]),
                 "ontime":        not item.legs[ 0].departureDelay,
                 "products":      ", ".join([x.name for x in item.legs if x.name is not None]),
@@ -36,11 +36,11 @@ def to_dict(item):
                 "origin":           item.origin.name,
                 "departure":        item.departure,
                 "platform":         item.departurePlatform,
-                "delay":            timedelta_to_dict(item.departureDelay),
+                "delay":            timedelta_to_str(item.departureDelay),
                 "destination":      item.destination.name,
                 "arrival":          item.arrival,
                 "platform_arrival": item.arrivalPlatform,
-                "delay_arrival":    timedelta_to_dict(item.arrivalDelay),
+                "delay_arrival":    timedelta_to_str(item.arrivalDelay),
                 "mode":             str(item.mode).lower()[5:],
                 "name":             item.name,
                 "canceled":         item.cancelled,

--- a/custom_components/hafas/utils.py
+++ b/custom_components/hafas/utils.py
@@ -1,6 +1,9 @@
 from datetime import date, datetime, timedelta
 from pyhafas.types.fptf import Journey, Leg, Remark, Stopover
 
+def timedelta_to_dict(item):
+    return str(item) if item else '0:00:00'
+
 # see https://gist.github.com/sungitly/3f75cb297572dace2937?permalink_comment_id=4211196#gistcomment-4211196
 def to_dict(item):
     match item:
@@ -16,10 +19,10 @@ def to_dict(item):
             return {
                 "origin":        item.legs[ 0].origin.name,
                 "departure":     item.legs[ 0].departure,
-                "delay":         to_dict(item.legs[ 0].departureDelay),
+                "delay":         timedelta_to_dict(item.legs[ 0].departureDelay),
                 "destination":   item.legs[-1].destination.name,
                 "arrival":       item.legs[-1].arrival,
-                "delay_arrival": to_dict(item.legs[-1].arrivalDelay),
+                "delay_arrival": timedelta_to_dict(item.legs[-1].arrivalDelay),
                 "transfers":     len(item.legs) - 1,
                 "duration":      str(item.duration),
                 "canceled":      any([x.cancelled for x in item.legs]),
@@ -33,11 +36,11 @@ def to_dict(item):
                 "origin":           item.origin.name,
                 "departure":        item.departure,
                 "platform":         item.departurePlatform,
-                "delay":            to_dict(item.departureDelay),
+                "delay":            timedelta_to_dict(item.departureDelay),
                 "destination":      item.destination.name,
                 "arrival":          item.arrival,
                 "platform_arrival": item.arrivalPlatform,
-                "delay_arrival":    to_dict(item.arrivalDelay),
+                "delay_arrival":    timedelta_to_dict(item.arrivalDelay),
                 "mode":             str(item.mode).lower()[5:],
                 "name":             item.name,
                 "canceled":         item.cancelled,
@@ -53,7 +56,7 @@ def to_dict(item):
             return item.stop.name + (" (canceled)" if item.cancelled else "")
 
         case timedelta():
-            return str(item)
+            return timedelta_to_dict(item)
 
         case None:
             return item

--- a/custom_components/hafas/utils.py
+++ b/custom_components/hafas/utils.py
@@ -1,0 +1,62 @@
+from datetime import date, datetime, timedelta
+from pyhafas.types.fptf import Journey, Leg, Remark, Stopover
+
+# see https://gist.github.com/sungitly/3f75cb297572dace2937?permalink_comment_id=4211196#gistcomment-4211196
+def to_dict(item):
+    match item:
+        #case dict():
+        #    return {k: to_dict(v) for k, v in item.items()}
+        #case object(__dict__=_):
+        #    return {k: v for k, v in vars(item).items()}
+
+        case list() | tuple():
+            return [to_dict(x) for x in item]
+
+        case Journey():
+            return {
+                "origin":        item.legs[ 0].origin.name,
+                "departure":     item.legs[ 0].departure,
+                "delay":         to_dict(item.legs[ 0].departureDelay),
+                "destination":   item.legs[-1].destination.name,
+                "arrival":       item.legs[-1].arrival,
+                "delay_arrival": to_dict(item.legs[-1].arrivalDelay),
+                "transfers":     len(item.legs) - 1,
+                "duration":      str(item.duration),
+                "canceled":      any([x.cancelled for x in item.legs]),
+                "ontime":        not item.legs[ 0].departureDelay,
+                "products":      ", ".join([x.name for x in item.legs if x.name is not None]),
+                "legs":          to_dict(item.legs or []),
+            } if item.legs else None
+
+        case Leg():
+            return {
+                "origin":           item.origin.name,
+                "departure":        item.departure,
+                "platform":         item.departurePlatform,
+                "delay":            to_dict(item.departureDelay),
+                "destination":      item.destination.name,
+                "arrival":          item.arrival,
+                "platform_arrival": item.arrivalPlatform,
+                "delay_arrival":    to_dict(item.arrivalDelay),
+                "mode":             str(item.mode).lower()[5:],
+                "name":             item.name,
+                "canceled":         item.cancelled,
+                "distance":         item.distance,
+                "remarks":          to_dict(item.remarks or []),
+                "stopovers":        to_dict(item.stopovers or []),
+            }
+
+        case Remark():
+            return item.text
+
+        case Stopover():
+            return item.stop.name + (" (canceled)" if item.cancelled else "")
+
+        case timedelta():
+            return str(item)
+
+        case None:
+            return item
+
+        case _:
+            return str(item)

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
     "homeassistant": "2022.11.0",
     "hacs": "0.19.0",
     "hide_default_branch": false,
-    "render_readme": true,
+    "render_readme": true
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
-  "name": "HAFAS (HaCon Fahrplan-Auskunfts-System) client",
-  "homeassistant": "2022.11.0",
-  "hacs": "0.19.0",
-  "hide_default_branch": false,
-  "render_readme": true
+    "name": "HAFAS (HaCon Fahrplan-Auskunfts-System) client",
+    "homeassistant": "2022.11.0",
+    "hacs": "0.19.0",
+    "hide_default_branch": false,
+    "render_readme": true,
 }


### PR DESCRIPTION
BREAKING CHANGE: 

This changes the `state` to be the actual `timestamp` of the next non-cancelled departure including delay. This allows to use the `state` programmatically, e.g. to compute a `timedelta` from it. Also, the sensor will be shown natively as a relative time, such as "in 5 minutes".

This also changes the `attributes` to allow for a list of `connections` to be returned. The following `attributes` are provided:
* ~"next": timestamp of next (i.e. second) departure including delay~
* ~"next_on": timestamp of over-next (i.e. third) departure including delay~
* "connections": all connections retrieved (max 3 currently)
* plus all information from the first connection, except the list of legs

Where a connection provides the following information:
* "origin": name of origin station 
* "departure": timestamp of planned departure 
* "delay": timedelta of departure delay 
* "destination": name of destination station 
* "arrival": timestamp of planned arrival 
* "delay_arrival": timedelta of arrival delay 
* "transfers": number of legs minus one
* "duration": timedelta departure to arrival
* "canceled": if any leg is cancelled
* "ontime": if no departure delay 
* "products": comma-separated list of line names
* "legs": list of legs with more detailed information


Where each leg contains the following information:
* "origin": name of origin station
* "departure": timestamp of planned departure
* "platform": departure platform
* "delay": timedelta of departure delay
* "destination": name of destination station 
* "arrival": timestamp of planned arrival 
* "platform_arrival": arrival platform 
* "delay_arrival": timedelta of arrival delay
* "mode": transport mode such as `train`
* "name": name of transport such as `RE123`
* "canceled": Boolean 
* "distance": walking distance if any
* "remarks": list of strings
* "stopovers": list of station names


Related: #4 