### PR TITLE
Adds new rkrp profile (Rejseplanen)

### DIFF
--- a/custom_components/hafas/__init__.py
+++ b/custom_components/hafas/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pyhafas import HafasClient
-from pyhafas.profile import DBProfile, KVBProfile, VSNProfile
+from pyhafas.profile import DBProfile, KVBProfile, VSNProfile, RKRPProfile
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -26,6 +26,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         client = HafasClient(KVBProfile())
     elif entry.data[CONF_PROFILE] == Profile.VSN:
         client = HafasClient(VSNProfile())
+    elif entry.data[CONF_PROFILE] == Profile.RKRP:
+        client = HafasClient(RKRPProfile())
 
     hass.data[DOMAIN][entry.entry_id] = client
 

--- a/custom_components/hafas/config_flow.py
+++ b/custom_components/hafas/config_flow.py
@@ -6,7 +6,7 @@ from typing import Any
 from enum import StrEnum
 
 from pyhafas import HafasClient
-from pyhafas.profile import DBProfile, KVBProfile, VSNProfile
+from pyhafas.profile import DBProfile, KVBProfile, VSNProfile, RKRPProfile
 from pyhafas.types.fptf import Station
 import voluptuous as vol
 
@@ -27,6 +27,7 @@ class Profile(StrEnum):
     DB = "DB"
     KVB = "KVB"
     VSN = "VSN"
+    RKRP = "RKRP"
 
 
 PROFILE_OPTIONS = [
@@ -38,6 +39,7 @@ PROFILE_OPTIONS = [
     selector.SelectOptionDict(
         value=Profile.VSN, label="Verkehrsverbund Süd-Niedersachsen"
     ),
+    selector.SelectOptionDict(value=Profile.RKRP, label="Rejseplanen"),
 ]
 
 DEFAULT_OFFSET = {"seconds": 0}
@@ -118,6 +120,8 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
         client = HafasClient(KVBProfile())
     elif data[CONF_PROFILE] == Profile.VSN:
         client = HafasClient(VSNProfile())
+    elif data[CONF_PROFILE] == Profile.RKRP:
+        client = HafasClient(RKRPProfile())
 
     start_stations = await hass.async_add_executor_job(
         get_stations, client, data[CONF_START]


### PR DESCRIPTION
This adds support for the RKRP Profile for Danish public transport (via Rejseplanen.dk). 
The profile is not yet updated in pyhafas documentation, but it is available in the code.

I couldn't figure out how to install my own fork in HACS to test this in HA, but I'm happy to test it out in a pre-release version if possible :)