### PR TITLE
Make destination station optional

### DIFF
--- a/custom_components/hafas/utils.py
+++ b/custom_components/hafas/utils.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime, timedelta
-from pyhafas.types.fptf import Journey, Leg, Remark, Stopover
+from pyhafas.types.fptf import Journey, Leg, Remark, Stopover, StationBoardLeg
+
 
 def timedelta_to_str(item):
     return str(item) if item else '0:00:00'
@@ -47,6 +48,18 @@ def to_dict(item):
                 "distance":         item.distance,
                 "remarks":          to_dict(item.remarks or []),
                 "stopovers":        to_dict(item.stopovers or []),
+            }
+
+        case StationBoardLeg():
+            return {
+                "origin":           item.station.name,
+                "departure":        item.dateTime,
+                "platform":         item.platform,
+                "delay":            timedelta_to_str(item.delay),
+                "ontime":           not item.delay,
+                "destination":      item.direction,
+                "name":             item.name,
+                "canceled":         item.cancelled,
             }
 
         case Remark():


### PR DESCRIPTION
When no destination is provided, we return all departures.

This can be presented using something like:

```yaml
type: custom:mushroom-template-card
secondary: >-
  {%- set connections = state_attr(entity, 'connections') -%}
  {%- if connections -%}
    {%- for connection in connections[:5] -%}
    {%- set departure = connection.departure | as_local -%}
    {{'\n'}}
      {%- if not connection.ontime -%}
      {%- set delay = connection.delay -%}
      {%- set delay_minutes = delay.split(':')[1] | int -%}
      {%- set new_departure = departure + timedelta(minutes=delay_minutes) -%}
      {{ new_departure.strftime('%H:%M') ~ ' — Forsinket ' ~ delay_minutes ~ ' min - tidspunkt er korrigeret' }}
      {%- else -%}
        {%- set departure = connection.departure | as_local -%}
        {{- departure.strftime('%H:%M') -}}
        {%- if not loop.last -%}
        {%- endif -%}
      {%- endif -%}
      {{' '}}{{ '%-18s' % connection.name }} {{ connection.destination }}
    {%- endfor -%}
  {%- else -%}
    No departures found
  {%- endif -%}
icon: mdi:bus
icon_color: >-
  {% set connections = state_attr(entity, 'connections') %}{% if connections and
  connections[0].canceled %}
    red
  {% elif connections and not connections[0].ontime %}
    yellow
  {% else %}
    green
  {% endif %}
grid_options:
  columns: full
multiline_secondary: true
entity: sensor.skelagervej_skelagergardene_aalborg_departures
primary: "{{ state_attr(entity, 'origin') }}"
```

I'm sure it could be improved, but I'd rather share it than let it sit on my computer.